### PR TITLE
Run Cosmos3-Edge at real width and strike both of its passes

### DIFF
--- a/eval/cosmos3_edge/README.md
+++ b/eval/cosmos3_edge/README.md
@@ -1,0 +1,63 @@
+# Cosmos3-Edge evaluation
+
+The generalization arm. LingBot-VA answers "does the stack make *this* model fast"; Cosmos3-Edge
+answers "is the stack a framework or a LingBot-VA optimizer with ambitions".
+
+Results and protocol: [RESULTS.md](RESULTS.md).
+
+## Setup
+
+Cosmos runs in **upstream's own environment**, never in `.venv-server`.
+
+```bash
+git clone https://github.com/NVIDIA/cosmos-framework /home/ubuntu/cosmos-framework
+cd /home/ubuntu/cosmos-framework && uv sync --group=cu130-torch213
+```
+
+`/home/ubuntu/cosmos-framework` is not a preference — `tests/test_cosmos3_engine.py:17` and
+`tests/test_p3_cosmos3.py:28` hardcode it on `sys.path`.
+
+Use `cu130-torch213`, not `cu130-train`, for three reasons:
+
+1. It pins cuDNN to `9.20.0.48`, which equals `CUDNN_MIN_BACKEND_VERSION` in
+   `cosmos_framework/model/attention/cudnn/__init__.py`, so the **cuDNN attention backend stays
+   enabled** instead of falling back. That is what removes the torch-SDPA shim.
+2. It ships **no flash-attn** (upstream has no torch213 build yet). The LingBot-VA baseline depends
+   on flash-attn being undetectable — `/home/ubuntu/iwm_shims/flash_attn` raises on call and carries
+   no package metadata precisely so `diffusers` cannot find it and switch `autoencoder_kl_wan` to a
+   flash path, which would move the VAE numerics and invalidate 91.6%. A group that installs
+   flash-attn into a shared interpreter would break that; this one cannot.
+3. It skips the `train` extra (megatron-core, DALI, torchtitan, lerobot), none of which the engine
+   tests touch.
+
+## Running
+
+```bash
+/home/ubuntu/cosmos-framework/.venv/bin/python eval/cosmos3_edge/probe_mot_stack.py
+```
+
+| flag | |
+|:--|:--|
+| `--layers N` | default 28, the shipped depth |
+| `--iters` / `--repeats` | default 20 × 3; median reported with spread |
+| `--shim` | force the old torch-SDPA shim, to quantify what it was hiding |
+
+Engine mechanics, separately:
+
+```bash
+/home/ubuntu/cosmos-framework/.venv/bin/python tests/test_cosmos3_engine.py
+```
+
+## Two ways this benchmark can lie to you
+
+**Toy width.** The config in `instinctwm/adapters/cosmos3.py:build_stack` is hidden 512 / head_dim 64,
+chosen because the cuDNN SDPA of the day rejected 128. Cost *ranking* at that width does not survive
+to 2048, and a benchmark that reports a ratio from toy shapes is reporting the wrong model.
+`probe_mot_stack.py` uses the shipped geometry for exactly this reason.
+
+**Region scale.** A pass that eliminates 896 allocations and 0.97 GiB per control step sounds
+decisive and measures 1.000× on the path that ships. This is the fused RoPE kernel's lesson again
+(`d5aae5e`: bit-exact, 1.10× at region scale, 0.3% of the cycle, did not ship) arriving from a
+different direction — there the region was too small to resolve, here it is large and already
+subsumed by capture. Both fail the same gate. Gate on the cycle. Section 4 of
+[RESULTS.md](RESULTS.md) is that story in full.

--- a/eval/cosmos3_edge/RESULTS.md
+++ b/eval/cosmos3_edge/RESULTS.md
@@ -1,0 +1,131 @@
+# Cosmos3-Edge — first end-to-end run under the InstinctWM engine
+
+Second reference model. Everything below was produced by
+[`probe_mot_stack.py`](probe_mot_stack.py) on this box, against a fresh upstream checkout.
+
+```bash
+/home/ubuntu/cosmos-framework/.venv/bin/python eval/cosmos3_edge/probe_mot_stack.py
+```
+
+## Substrate
+
+| | |
+|:--|:--|
+| upstream | [`NVIDIA/cosmos-framework`](https://github.com/NVIDIA/cosmos-framework) @ `12a9a81` (2026-08-07) |
+| environment | upstream's own lock, `uv sync --group=cu130-torch213` → `/home/ubuntu/cosmos-framework/.venv` |
+| torch | 2.13.0+cu130, cuDNN 92000, Python 3.13.14 |
+| GPU | 1× A100-SXM4-80GB |
+| attention | **cuDNN, both paths — the real dispatched kernel, no shim** |
+| geometry | 28 layers, hidden 2048, 16q/8kv heads, head_dim 128, intermediate 9216 (`nvidia/Cosmos3-Edge` `config.json` → `text_config`) |
+| pack | `sample_lens=[567]`, `split_lens=[111, 456]`, `attn_modes=["causal","full"]`, NFE 16 |
+| params | 3.876 B (7.22 GiB bf16) |
+| protocol | 20 iters × 3 repeats, median reported, spread shown |
+
+**Not claimed: accuracy.** Random weights, no checkpoint. What is claimed is op structure, shapes,
+dependency derivation, capturability, eager-vs-replay equality, and allocation traffic.
+
+The environment is deliberately separate from `.venv-server`. The `cu130-torch213` group ships
+**no flash-attn** — which is what keeps `/home/ubuntu/iwm_shims/flash_attn` (the RuntimeError shim
+with no package metadata) doing its job, so `diffusers` cannot detect flash-attn, switch
+`autoencoder_kl_wan` to a flash path, and invalidate the 91.6% RoboTwin baseline. Verified after
+the run: `.venv-server` untouched, no flash-attn, no natten.
+
+## 1. The engine generalized, unchanged
+
+The adapter and the engine were written against a Cosmos tree from an earlier release. Neither was
+modified. On today's HEAD:
+
+```
+5320 ops, 624 external reads, 0 unnamed
+capturable: True (no host mutation detected in the traced execution)
+```
+
+`0 unnamed` closes the open finding from `tests/test_cosmos3_engine.py` — `build_name_map` no
+longer needs adapter-supplied naming for this model.
+
+## 2. One Plan, both executors, bit-exact
+
+```
+graph replay vs eager oracle : differing=0  max|d|=0.000e+00  BITEXACT   (captures=1)
+second pack, new values      : differing=0  captures still 1 (rebound, not recaptured)
+```
+
+## 3. Latency — GRAPH is 2.33× on the control step
+
+| | ms / forward | enqueue | spread | × NFE 16 (control step) | vs raw eager |
+|:--|--:|--:|--:|--:|--:|
+| raw eager (no engine) | 66.010 | 66.000 | 1.0% | 1056.2 ms | 1.000× |
+| EagerExecutor | 65.897 | 65.886 | 0.6% | 1054.4 ms | 1.002× |
+| **GraphExecutor (replay)** | **28.393** | 5.684 | 0.0% | **454.3 ms** | **2.325×** |
+
+Across five independent invocations the graph figure was 2.300× / 2.325× / 2.327× / 2.342× /
+2.361×. Quote the range, not the best one: the eager arm carries a 0.6–1.6% spread and the graph
+arm effectively none (28.39–28.41 ms every time), so the ratio's variance is entirely the
+denominator's.
+
+`EagerExecutor` at 1.002× is the control that matters: the engine's own dispatch costs nothing, so
+the win is capture, not bookkeeping. Eager is launch-bound (enqueue 66.000 ≈ wall 66.010); replay
+drops enqueue to 5.684 ms and lands GPU-bound at 28.4 ms.
+
+## 4. L3-P8 (ForwardScratchArena): **rejected by measurement**
+
+The declaration is intact at this commit. `get_all_seq` (`runtime.py:505-525`) still allocates
+`new_zeros` and scatters twice; `attention.py:205-206` still calls it twice in one expression with
+K and V live simultaneously; `set_all_seq` (`:528`) is still never called, so the `all_seq` memo at
+`:513` never fires and every call takes the allocating path.
+
+Measured:
+
+```
+per forward      :  56 calls   62.02 MiB   (2 per layer)
+per control step : 896 calls    0.97 GiB   (NFE 16)
+```
+
+The call count matches the manifest's 896 exactly. The **byte figure does not**: the manifest says
+~2.08 GB, the truth is 0.97 GiB. The estimate assumed full hidden width; `get_all_seq` runs on K and
+V, which are GQA-narrowed to 8 heads × 128 = 1024, not 2048. The manifest over-counts by 2.1×.
+
+Ceiling probe — two preallocated per-role buffers, rotated, which is the minimum that cannot alias
+and is exactly `ForwardScratchArena`'s structural safety argument:
+
+```
+bit-exact vs allocating path: differing=0  max|d|=0.000e+00
+EAGER   66.010 -> 65.346 ms/fwd   1.010x
+GRAPH   28.393 -> 28.391 ms/fwd   1.000x
+=> P8 ceiling on the CYCLE: 1.010x eager, 1.000x on the shipped (graph) path
+```
+
+Removing **all** 896 allocations and the whole 0.97 GiB buys 1.0% on eager and nothing at all on the
+path that would actually ship. CUDA graph capture already bakes the allocations into its private
+pool, so P8 is not merely small here — it is **subsumed**. Struck, and kept so it is not
+re-proposed.
+
+## 5. L3-P3 (StaticPartitionHoist): **obsolete — upstream implemented it**
+
+`tests/test_p3_cosmos3.py` no longer runs:
+
+```
+AttributeError: module '...sequence_packing.runtime' has no attribute 'init_sequence_pack'
+```
+
+Upstream refactored `init_sequence_pack` into `SequencePackMetadata` +
+`prepare_sequence_pack_metadata` + a `prepared_metadata=` parameter on
+`sequence_pack_from_packed_sequence` guarded by `matches_layout()`. That is P3's memoization, built
+by NVIDIA, as opt-in reuse — and `cosmos3_vfm_network.py:1017` passes it on the served path, so the
+win is already taken.
+
+What survives of the original finding: the `.tolist()` device→host sync (`runtime.py:243`) and the
+assert-only product it feeds (`:245`) are still there.
+
+## Where this leaves the layer table
+
+| layer | on Cosmos3-Edge |
+|:--|:--|
+| GRAPH | **2.33× bit-exact on the control step** (2.30–2.36× over five runs). The whole measured win. |
+| CACHE | Nothing to reuse — no KV pool; the SequencePack is the state. |
+| MODEL / ATTENTION / KERNEL / HARDWARE | Unbuilt for this model. |
+| ~~L3-P3~~ | Obsolete, implemented upstream. |
+| ~~L3-P8~~ | 1.000× on the shipped path. Subsumed by GRAPH. |
+
+Both of the passes written specifically for Cosmos3-Edge are dead, and the one that generalized
+from LingBot-VA is the one that paid. That is the opposite of what the manifest predicted.

--- a/eval/cosmos3_edge/probe_mot_stack.py
+++ b/eval/cosmos3_edge/probe_mot_stack.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Cosmos3-Edge MoT stack under the InstinctWM engine, at the REAL served width.
+
+Replaces the toy config in instinctwm/adapters/cosmos3.py (hidden 512 / head_dim 64) with the
+shipped Cosmos3-Edge text-tower geometry read off nvidia/Cosmos3-Edge config.json:
+
+    hidden 2048, 28 layers, 16 q heads, 8 kv heads, head_dim 128, intermediate 9216
+
+and drops the torch-SDPA shim: the cuDNN backend resolves at these shapes on this box, so the
+attention kernel is the one Cosmos actually dispatches to.
+
+STILL NOT a served-accuracy claim: random weights, no checkpoint. What IS claimed is op
+structure, shapes, dependency derivation, capturability, eager-vs-replay equality, and the
+allocation traffic a pass would target.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+import time
+
+sys.path.insert(0, "/home/ubuntu/cosmos-framework")
+sys.path.insert(0, "/home/ubuntu/Code/InstinctWM")
+
+import torch
+
+# Shipped Cosmos3-Edge text tower (nvidia/Cosmos3-Edge config.json -> text_config).
+EDGE = dict(hidden_size=2048, num_hidden_layers=28, num_attention_heads=16,
+            num_key_value_heads=8, head_dim=128, intermediate_size=9216, rms_norm_eps=1e-5)
+
+# Served pack geometry, as declared in instinctwm/runtime/state/manifests.py:cosmos3_edge_manifest.
+SAMPLE_LENS = [567]
+SPLIT_LENS = [111, 456]          # und (text) prefix, gen (video+action) body
+ATTN_MODES = ["causal", "full"]
+NFE = 16                         # forwards per control step, the served rung
+
+
+def build_stack(n_layers, device, dtype=torch.bfloat16):
+    from cosmos_framework.model.generator.mot.unified_mot import LayerTypes, MoTDecoderLayer
+    from cosmos_framework.model.generator.reasoner.qwen3_vl.configuration_qwen3_vl import (
+        Qwen3VLTextConfig,
+    )
+    cfg = Qwen3VLTextConfig(
+        hidden_size=EDGE["hidden_size"], num_attention_heads=EDGE["num_attention_heads"],
+        num_key_value_heads=EDGE["num_key_value_heads"], num_hidden_layers=n_layers,
+        intermediate_size=EDGE["intermediate_size"], head_dim=EDGE["head_dim"],
+        rms_norm_eps=EDGE["rms_norm_eps"], attention_bias=False,
+    )
+    lt = LayerTypes("qwen3_vl_dense")
+    layers = [MoTDecoderLayer(cfg, layer_idx=i, layer_types=lt,
+                              qk_norm_for_text=True, qk_norm_for_diffusion=True)
+              .to(device, dtype).eval() for i in range(n_layers)]
+    for l in layers:
+        l.requires_grad_(False)
+    return cfg, layers
+
+
+def build_pack(device, hidden, dtype, seed=0):
+    from cosmos_framework.data.generator.sequence_packing.runtime import (
+        sequence_pack_from_packed_sequence,
+    )
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    und, gen = SPLIT_LENS
+    seq = torch.randn(sum(SAMPLE_LENS), hidden, generator=g).to(device, dtype)
+    return sequence_pack_from_packed_sequence(
+        packed_sequence=seq, attn_modes=ATTN_MODES, split_lens=SPLIT_LENS,
+        sample_lens=list(SAMPLE_LENS),
+        packed_und_token_indexes=torch.tensor(list(range(und)), device=device),
+        packed_gen_token_indexes=torch.tensor(list(range(und, und + gen)), device=device))
+
+
+def bench(fn, iters, repeats, warmup=5):
+    """Returns (median wall ms, median enqueue ms, spread %) over `repeats` independent runs."""
+    walls, enqs = [], []
+    for _ in range(repeats):
+        for _ in range(warmup):
+            fn()
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            fn()
+        enqs.append((time.perf_counter() - t0) / iters * 1e3)
+        torch.cuda.synchronize()
+        walls.append((time.perf_counter() - t0) / iters * 1e3)
+    spread = (max(walls) - min(walls)) / statistics.median(walls) * 100
+    return statistics.median(walls), statistics.median(enqs), spread
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--layers", type=int, default=EDGE["num_hidden_layers"])
+    ap.add_argument("--iters", type=int, default=20)
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--shim", action="store_true", help="force the torch-SDPA shim instead of cuDNN")
+    args = ap.parse_args()
+
+    if not torch.cuda.is_available():
+        print("SKIP: needs CUDA")
+        return 0
+    dev, dt = torch.device("cuda"), torch.bfloat16
+    torch.manual_seed(0)
+
+    sha = os.popen("git -C /home/ubuntu/cosmos-framework rev-parse --short HEAD").read().strip()
+    print("=" * 92)
+    print("Cosmos3-Edge MoT stack -- InstinctWM engine, real served width")
+    print("=" * 92)
+    print(f"  torch {torch.__version__}  cudnn {torch.backends.cudnn.version()}  "
+          f"{torch.cuda.get_device_name(0)}")
+    print(f"  cosmos-framework @ {sha}   (uv group cu130-torch213, no flash-attn)")
+    print(f"  config: {args.layers} layers, hidden {EDGE['hidden_size']}, "
+          f"{EDGE['num_attention_heads']}q/{EDGE['num_key_value_heads']}kv heads, "
+          f"head_dim {EDGE['head_dim']}, intermediate {EDGE['intermediate_size']}")
+    print(f"  pack:   sample_lens={SAMPLE_LENS} split_lens={SPLIT_LENS} "
+          f"modes={ATTN_MODES}, NFE={NFE}")
+    print(f"  protocol: {args.iters} iters x {args.repeats} repeats, median reported, spread shown")
+
+    # ---- attention backend -------------------------------------------------------------
+    if args.shim:
+        from instinctwm.adapters.cosmos3 import use_torch_sdpa
+        backend = use_torch_sdpa()
+    else:
+        from cosmos_framework.model.attention.backends import choose_backend
+        from cosmos_framework.model.attention.masks import CausalType
+        und, gen, tot = SPLIT_LENS[0], SPLIT_LENS[1], sum(SAMPLE_LENS)
+        nq, nkv, hd = (EDGE["num_attention_heads"], EDGE["num_key_value_heads"], EDGE["head_dim"])
+        sz = torch.Size
+        bc = choose_backend(sz((1, und, nq, hd)), sz((1, und, nkv, hd)), sz((1, und, nkv, hd)),
+                            dt, dev, requires_grad=False, is_causal=True,
+                            causal_type=CausalType.TopLeft, is_varlen=False, raise_error=False)
+        bf = choose_backend(sz((1, gen, nq, hd)), sz((1, tot, nkv, hd)), sz((1, tot, nkv, hd)),
+                            dt, dev, requires_grad=False, is_causal=False, causal_type=None,
+                            is_varlen=False, raise_error=False)
+        backend = f"{bc} (causal) / {bf} (full)  -- REAL kernel, no shim"
+    print(f"  attention backend: {backend}")
+
+    cfg, layers = build_stack(args.layers, dev, dt)
+    nparam = sum(p.numel() for l in layers for p in l.parameters())
+    print(f"  params: {nparam / 1e9:.3f} B  ({nparam * 2 / 2**30:.2f} GiB bf16)")
+
+    pack = build_pack(dev, cfg.hidden_size, dt)
+    from cosmos_framework.data.generator.sequence_packing.runtime import get_all_seq, zeros_like
+    from cosmos_framework.model.generator.mot.attention import SplitInfo
+
+    hd = EDGE["head_dim"]
+    cos, sin = zeros_like(pack, (-1, hd)), zeros_like(pack, (-1, hd))
+    for p in (cos, sin):
+        p["causal_seq"] = torch.randn_like(p["causal_seq"])
+        p["full_only_seq"] = torch.randn_like(p["full_only_seq"])
+    pos = (cos, sin)
+    mask = SplitInfo(split_lens=list(SPLIT_LENS), attn_modes=list(ATTN_MODES),
+                     sample_lens=list(SAMPLE_LENS), actual_len=sum(SAMPLE_LENS))
+
+    def stack(inp):
+        x = inp
+        for l in layers:
+            x = l(x, mask, pos)[0]
+        return x
+
+    # ---- 1. dependency derivation ------------------------------------------------------
+    from instinctwm.adapters.cosmos3 import build_plan, state_roots
+    from instinctwm.planners.deps import derive_signature
+
+    print("\n--- 1. dependency signature (engine, unchanged) ------------------------------")
+    with torch.no_grad():
+        sig = derive_signature(lambda: stack(pack), roots=[pack, cos, sin],
+                               name_roots=state_roots(layers, pack, pos))
+    cap, why = sig.capturable()
+    print(f"  {sig.n_ops} ops, {len(sig.reads)} external reads, {sig.unnamed_reads} unnamed")
+    print(f"  capturable: {cap} ({why})")
+
+    # ---- 2. one Plan, both executors ---------------------------------------------------
+    from instinctwm.executors.executor import EagerExecutor, GraphExecutor
+
+    print("\n--- 2. one Plan under EagerExecutor and GraphExecutor ------------------------")
+    plan = build_plan(layers, mask, pos)
+    eager, graph = EagerExecutor(plan, dev), GraphExecutor(plan, dev)
+    graph.prepare()
+
+    ref = get_all_seq(eager.run("mot_stack/default", pack=pack)).clone()
+    got = get_all_seq(graph.run("mot_stack/default", pack=pack))
+    nd = (got != ref).sum().item()
+    md = (got.float() - ref.float()).abs().max().item()
+    print(f"  graph replay vs eager oracle : differing={nd}  max|d|={md:.3e}  "
+          f"{'BITEXACT' if nd == 0 else 'MISMATCH'}   (captures={graph.n_captures})")
+    pack2 = build_pack(dev, cfg.hidden_size, dt, seed=7)
+    ref2 = get_all_seq(eager.run("mot_stack/default", pack=pack2)).clone()
+    got2 = get_all_seq(graph.run("mot_stack/default", pack=pack2))
+    nd2 = (got2 != ref2).sum().item()
+    print(f"  second pack, new values      : differing={nd2}  "
+          f"captures still {graph.n_captures} (rebound, not recaptured)")
+
+    # ---- 3. latency --------------------------------------------------------------------
+    print("\n--- 3. latency ---------------------------------------------------------------")
+    with torch.no_grad():
+        r_ms, r_enq, r_sp = bench(lambda: stack(pack), args.iters, args.repeats)
+    e_ms, e_enq, e_sp = bench(lambda: eager.run("mot_stack/default", pack=pack),
+                              args.iters, args.repeats)
+    g_ms, g_enq, g_sp = bench(lambda: graph.run("mot_stack/default", pack=pack),
+                              args.iters, args.repeats)
+    print(f"  {'':24s}{'fwd (ms)':>10s}{'enqueue':>10s}{'spread':>9s}"
+          f"{'control step x16':>19s}{'vs raw eager':>14s}")
+    for nm, ms, eq, sp in (("raw eager (no engine)", r_ms, r_enq, r_sp),
+                           ("EagerExecutor", e_ms, e_enq, e_sp),
+                           ("GraphExecutor (replay)", g_ms, g_enq, g_sp)):
+        print(f"  {nm:24s}{ms:10.3f}{eq:10.3f}{sp:8.1f}%{ms * NFE:17.1f} ms{r_ms / ms:13.3f}x")
+
+    # ---- 4. P8 target: get_all_seq alloc traffic, and its measured ceiling --------------
+    print("\n--- 4. L3-P8 target: get_all_seq allocate-and-scatter ------------------------")
+    import cosmos_framework.model.generator.mot.attention as mot_attn
+    _orig = mot_attn.get_all_seq
+
+    stats = {"calls": 0, "bytes": 0}
+
+    def counting(p):
+        out = _orig(p)
+        stats["calls"] += 1
+        stats["bytes"] += out.numel() * out.element_size()
+        return out
+
+    mot_attn.get_all_seq = counting
+    with torch.no_grad():
+        stack(pack)
+    mot_attn.get_all_seq = _orig
+    calls, byts = stats["calls"], stats["bytes"]
+    print(f"  per forward      : {calls:5d} calls  {byts / 2**20:8.2f} MiB "
+          f"({calls // args.layers} per layer -- attention.py:205-206, K and V live together)")
+    print(f"  per control step : {calls * NFE:5d} calls  {byts * NFE / 2**30:8.2f} GiB (NFE {NFE})")
+    print(f"  'all_seq' memo in pack: {'all_seq' in pack}  "
+          f"(runtime.py:513; set_all_seq is never called, so every call allocates)")
+
+    # Measured ceiling: two preallocated per-role buffers, rotated. Two slots is the minimum
+    # that cannot alias, which is exactly ForwardScratchArena's structural safety argument.
+    slot = [torch.empty(sum(SAMPLE_LENS), EDGE["num_key_value_heads"], EDGE["head_dim"],
+                        device=dev, dtype=dt) for _ in range(2)]
+    turn = {"i": 0}
+
+    def pooled(p):
+        if "all_seq" in p:
+            return p["all_seq"]
+        buf = slot[turn["i"]]
+        turn["i"] ^= 1
+        buf.zero_()
+        ci, fi = p["_causal_indices"], p["_full_indices"]
+        if p["causal_seq"].shape[0] > 0:
+            buf[ci] = p["causal_seq"][: ci.shape[0]]
+        if p["full_only_seq"].shape[0] > 0:
+            buf[fi] = p["full_only_seq"][: fi.shape[0]]
+        return buf
+
+    with torch.no_grad():
+        base = get_all_seq(stack(pack)).clone()
+    mot_attn.get_all_seq = pooled
+    with torch.no_grad():
+        pooled_out = get_all_seq(stack(pack)).clone()
+        p_ms, p_enq, p_sp = bench(lambda: stack(pack), args.iters, args.repeats)
+    mot_attn.get_all_seq = _orig
+
+    pnd = (pooled_out != base).sum().item()
+    print(f"\n  ceiling probe -- 2-slot preallocated per-role scratch (no aliasing possible):")
+    print(f"    bit-exact vs allocating path: differing={pnd} "
+          f"max|d|={(pooled_out.float() - base.float()).abs().max().item():.3e}")
+    print(f"    EAGER  {r_ms:8.3f} -> {p_ms:8.3f} ms/fwd   {r_ms / p_ms:.3f}x  (spread {p_sp:.1f}%)")
+
+    # The shipped path is graph replay, where the allocations are baked into the graph's private
+    # pool. If P8 buys nothing THERE, it is subsumed rather than merely small.
+    mot_attn.get_all_seq = pooled
+    gp_plan = build_plan(layers, mask, pos, model_id="cosmos3-edge-pooled")
+    gp = GraphExecutor(gp_plan, dev)
+    gp.prepare()
+    gp_out = get_all_seq(gp.run("mot_stack/default", pack=pack)).clone()
+    gp_ms, gp_enq, gp_sp = bench(lambda: gp.run("mot_stack/default", pack=pack),
+                                 args.iters, args.repeats)
+    mot_attn.get_all_seq = _orig
+    gnd = (gp_out != base).sum().item()
+    print(f"    GRAPH  {g_ms:8.3f} -> {gp_ms:8.3f} ms/fwd   {g_ms / gp_ms:.3f}x  "
+          f"(spread {gp_sp:.1f}%, differing={gnd})")
+    print(f"    control step: eager {r_ms * NFE:.1f} -> {p_ms * NFE:.1f} ms | "
+          f"graph {g_ms * NFE:.1f} -> {gp_ms * NFE:.1f} ms")
+    print(f"    => P8 ceiling on the CYCLE: {r_ms / p_ms:.3f}x eager, {g_ms / gp_ms:.3f}x on the "
+          f"shipped (graph) path")
+
+    print("\n" + "=" * 92)
+    print("NOT a served-accuracy claim: random weights, no checkpoint. Claimed: op structure,")
+    print("shapes, dependency derivation, capturability, replay equality, allocation traffic.")
+    return 0 if nd == 0 and nd2 == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
First end-to-end measurement of the second reference model, against a fresh upstream checkout (NVIDIA/cosmos-framework @ 12a9a81) in upstream's own lock (uv group cu130-torch213). That group pins cuDNN to CUDNN_MIN_BACKEND_VERSION, so the cuDNN attention backend stays enabled and the torch-SDPA shim is gone -- the kernel is the one Cosmos dispatches to. It also ships no flash-attn, so the frozen LingBot-VA baseline cannot be disturbed; .venv-server verified untouched.

At the shipped geometry (28 layers, hidden 2048, 16q/8kv, head_dim 128, 3.876B, pack 111 und + 456 gen, NFE 16) the engine ran unchanged: 5320 ops, 0 unnamed reads, capturable, graph replay bit-exact against the eager oracle. GRAPH is 2.325x on the control step, 1056.2 -> 454.3 ms (2.30-2.36x over five runs), with EagerExecutor at 1.002x as the control that says the win is capture and not bookkeeping.

Both passes written specifically for this model are dead. P3 is obsolete: upstream deleted init_sequence_pack and rebuilt it as SequencePackMetadata plus a prepared_metadata= parameter, passed on the served path. P8 is rejected by measurement: its declaration is intact and it does cost 896 allocations and 0.97 GiB per control step, but removing all of it buys 1.010x eager and 1.000x on the graph path, because capture already bakes the allocations into its pool. Kept struck so neither is re-proposed. The manifest's 2.08 GB estimate is corrected to 0.97 GiB -- GQA narrows K/V to 1024, not 2048; its 896 was exact.